### PR TITLE
Author Search

### DIFF
--- a/examples/blog/configuration/storagesystems/default.yaml
+++ b/examples/blog/configuration/storagesystems/default.yaml
@@ -27,3 +27,7 @@ configuration:
     - categories.name
     - _content
     - _parents.name
+    - email
+    - displayName
+    - firstName
+    - lastName


### PR DESCRIPTION
## Summary
  - Implement author search functionality for collections page
  - Add support for Public Search integration when viewing Author collection types

  ## Changes Made
  - **Enhanced search functionality**: Collections page now uses Public Search for Author
  collection types, enabling broader search capabilities across author profiles
  - **Search integration**: Updated GraphQL queries and persisted documents to support the
  new search functionality

  ## Technical Details
  - Modified collections page to conditionally use search based on collection type
  - Updated search filter to target `type = "Author" AND _type = "collection"` when searching
   authors

  ## Test Plan
  - [ ] Verify author search works correctly on collections page
  - [ ] Confirm search results display properly for Author collection types
  - [ ] Test that non-Author collections continue to work as expected
  - [ ] Validate search performance and results accuracy

  ## Related Issues
  - Addresses BOSCA-65: Author Search functionality
  - Related to https://github.com/sowers-io/bosca-administration/pull/2