### PR TITLE
Add Comment to WorkflowJob for comment moderation support

### DIFF
--- a/workspace/runners/kotlin/engine/src/main/graphql/fragments/Comment.graphql
+++ b/workspace/runners/kotlin/engine/src/main/graphql/fragments/Comment.graphql
@@ -1,0 +1,16 @@
+fragment Comment on Comment {
+    id
+    content
+    created
+    modified
+    status
+    attributes
+    systemAttributes
+    deleted
+    parentId
+    profileId
+    visibility
+    metadataId
+    version
+    collectionId
+}

--- a/workspace/runners/kotlin/engine/src/main/graphql/fragments/WorkflowJob.graphql
+++ b/workspace/runners/kotlin/engine/src/main/graphql/fragments/WorkflowJob.graphql
@@ -22,6 +22,9 @@ fragment WorkflowJob on WorkflowJob {
     profile {
         ...Profile
     }
+    comment {
+        ...Comment
+    }
     activity {
         ...Activity
     }

--- a/workspace/runners/kotlin/engine/src/main/graphql/schema.graphqls
+++ b/workspace/runners/kotlin/engine/src/main/graphql/schema.graphqls
@@ -112,6 +112,30 @@ type CategoryMutation {
     edit(category: CategoryInput!, id: String!): Category!
 }
 
+type Comment {
+    attributes: JSON
+    content: String!
+    created: DateTime!
+    deleted: Boolean!
+    id: Long!
+    modified: DateTime!
+    parentId: Long
+    profile: Profile
+    profileId: String!
+    status: CommentStatus!
+    systemAttributes: JSON
+    visibility: ProfileVisibility!
+    metadataId: String
+    version: Int
+    collectionId: String
+}
+
+enum CommentStatus {
+    APPROVED
+    PENDING
+    PENDING_APPROVAL
+}
+
 type Collection {
     attributes(filter: AttributesFilterInput): JSON
     categories: [Category!]!
@@ -1122,6 +1146,7 @@ type WorkflowJob {
     children: [WorkflowExecutionId!]!
     collection: Collection
     collectionId: String
+    comment: Comment
     completedChildren: [WorkflowExecutionId!]!
     context: JSON
     error: String
@@ -1377,6 +1402,8 @@ scalar DateTime
 
 "A scalar that can represent any JSON value."
 scalar JSON
+
+scalar Long
 
 scalar Upload
 


### PR DESCRIPTION
  - Add Comment GraphQL fragment with all comment fields
  - Add comment field to WorkflowJob fragment
  - Add Comment type and CommentStatus enum to schema
  - Add Long scalar type for bigserial IDs
  - Enables workflow activities to access comment data